### PR TITLE
Add GroupTask

### DIFF
--- a/.idea/runConfigurations/All_Tests.xml
+++ b/.idea/runConfigurations/All_Tests.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="All Tests" type="JavaScriptTestRunnerJest" nameIsGenerated="true">
+    <node-interpreter value="project" />
+    <node-options value="" />
+    <jest-package value="yarn:package.json:jest" />
+    <working-dir value="$PROJECT_DIR$" />
+    <envs />
+    <scope-kind value="ALL" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jujulego/tasks",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "author": "Julien Capellari <julien.capellari@gmail.com>",
   "repository": {

--- a/src/group-task.ts
+++ b/src/group-task.ts
@@ -1,0 +1,91 @@
+import { AnyTask, Task, TaskContext, TaskEventMap, TaskOptions, TaskStatus } from './task';
+import { TaskManager } from './task-manager';
+
+// Types
+export interface GroupTaskEventMap extends TaskEventMap {
+  'task.added': Task;
+  'task.started': Task;
+  'task.completed': Task;
+}
+
+export type GroupTaskStats = Record<TaskStatus, number>;
+
+// Class
+export abstract class GroupTask<C extends TaskContext = TaskContext, M extends GroupTaskEventMap = GroupTaskEventMap> extends Task<C, M> {
+  // Attributes
+  private readonly _tasks: Task[] = [];
+
+  // Constructor
+  protected constructor(
+    readonly name: string,
+    context: C,
+    opts?: TaskOptions
+  ) {
+    super(context, opts);
+  }
+
+  // Methods
+  protected abstract _orchestrate(manager: TaskManager): void;
+
+  protected _start(manager?: TaskManager): void {
+    if (!manager) {
+      throw new Error('A GroupTask must be started using a TaskManager');
+    }
+
+    if (this._tasks.length > 0) {
+      this._orchestrate(manager);
+    } else {
+      this._logger.verbose(`no tasks in group ${this.name}`);
+      this.status = 'done';
+    }
+  }
+
+  protected _stop() {
+    // Stop all tasks
+    for (const task of this._tasks) {
+      task.stop();
+    }
+  }
+
+  add(task: AnyTask) {
+    if ((task as Task).context.groupTaskId) {
+      throw new Error(`Cannot add task ${task.name} to group ${this.name}, it's already in an other group.`);
+    }
+
+    // Register task
+    this._tasks.push(task);
+    (task as Task).context.groupTaskId = this.id;
+
+    // Listen to task events
+    (task as Task).subscribe('status.running', () => {
+      this.emit('task.started', task);
+    });
+
+    (task as Task).subscribe('completed', () => {
+      this.emit('task.completed', task);
+    });
+
+    this.emit('task.added', task);
+  }
+
+  // Properties
+  get tasks(): readonly Task[] {
+    return this._tasks;
+  }
+
+  get stats(): Readonly<GroupTaskStats> {
+    const stats: GroupTaskStats = {
+      blocked: 0,
+      ready: 0,
+      running: 0,
+      done: 0,
+      failed: 0,
+    };
+
+    for (const task of this._tasks) {
+      stats[task.status]++;
+    }
+
+    return stats;
+  }
+}

--- a/src/group-task.ts
+++ b/src/group-task.ts
@@ -16,7 +16,7 @@ export abstract class GroupTask<C extends TaskContext = TaskContext, M extends G
   private readonly _tasks: Task[] = [];
 
   // Constructor
-  protected constructor(
+  constructor(
     readonly name: string,
     context: C,
     opts?: TaskOptions

--- a/src/group-task.ts
+++ b/src/group-task.ts
@@ -25,15 +25,17 @@ export abstract class GroupTask<C extends TaskContext = TaskContext, M extends G
   }
 
   // Methods
-  protected abstract _orchestrate(manager: TaskManager): void;
+  protected abstract _orchestrate(): AsyncGenerator<Task>;
 
-  protected _start(manager?: TaskManager): void {
+  protected async _start(manager?: TaskManager): Promise<void> {
     if (!manager) {
       throw new Error('A GroupTask must be started using a TaskManager');
     }
 
     if (this._tasks.length > 0) {
-      this._orchestrate(manager);
+      for await (const task of this._orchestrate()) {
+        manager.add(task);
+      }
     } else {
       this._logger.verbose(`no tasks in group ${this.name}`);
       this.status = 'done';

--- a/src/group-task.ts
+++ b/src/group-task.ts
@@ -42,13 +42,6 @@ export abstract class GroupTask<C extends TaskContext = TaskContext, M extends G
     }
   }
 
-  protected _stop() {
-    // Stop all tasks
-    for (const task of this._tasks) {
-      task.stop();
-    }
-  }
-
   add(task: AnyTask) {
     assertIsTask(task);
 

--- a/src/group-task.ts
+++ b/src/group-task.ts
@@ -21,7 +21,7 @@ export abstract class GroupTask<C extends TaskContext = TaskContext, M extends G
     context: C,
     opts?: TaskOptions
   ) {
-    super(context, opts);
+    super(context, { weight: 0, ...opts });
   }
 
   // Methods

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './group-task';
 export * from './logger';
+export * from './parallel-group';
 export * from './spawn-task';
 export * from './task';
 export * from './task-manager';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export * from './group-task';
 export * from './logger';
 export * from './parallel-group';
+export * from './sequence-group';
 export * from './spawn-task';
 export * from './task';
 export * from './task-manager';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './group-task';
 export * from './logger';
 export * from './spawn-task';
 export * from './task';

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -6,6 +6,7 @@ export interface ILogger {
   debug(msg: string): void;
   verbose(msg: string): void;
   warn(msg: string): void;
+  error(msg: string, cause?: unknown): void;
 }
 
 // Types
@@ -13,4 +14,5 @@ export const logger: ILogger = {
   debug: console.debug,
   verbose: console.info,
   warn: console.warn,
+  error: console.error,
 };

--- a/src/parallel-group.ts
+++ b/src/parallel-group.ts
@@ -1,13 +1,12 @@
 import { GroupTask } from './group-task';
-import { TaskContext } from './task';
-import { TaskManager } from './task-manager';
+import { Task, TaskContext } from './task';
 
 // Class
 export class ParallelGroup<C extends TaskContext = TaskContext> extends GroupTask<C> {
   // Methods
-  protected _orchestrate(manager: TaskManager) {
+  protected async* _orchestrate(): AsyncGenerator<Task> {
     for (const task of this.tasks) {
-      manager.add(task);
+      yield task;
 
       task.subscribe('completed', () => {
         const stats = this.stats;

--- a/src/parallel-group.ts
+++ b/src/parallel-group.ts
@@ -17,4 +17,11 @@ export class ParallelGroup<C extends TaskContext = TaskContext> extends GroupTas
       });
     }
   }
+
+  protected _stop() {
+    // Stop all tasks
+    for (const task of this.tasks) {
+      task.stop();
+    }
+  }
 }

--- a/src/parallel-group.ts
+++ b/src/parallel-group.ts
@@ -1,0 +1,21 @@
+import { GroupTask } from './group-task';
+import { TaskContext } from './task';
+import { TaskManager } from './task-manager';
+
+// Class
+export class ParallelGroup<C extends TaskContext = TaskContext> extends GroupTask<C> {
+  // Methods
+  protected _orchestrate(manager: TaskManager) {
+    for (const task of this.tasks) {
+      manager.add(task);
+
+      task.subscribe('completed', () => {
+        const stats = this.stats;
+
+        if (stats.done + stats.failed === this.tasks.length) {
+          this.status = stats.failed > 0 ? 'failed' : 'done';
+        }
+      });
+    }
+  }
+}

--- a/src/sequence-group.ts
+++ b/src/sequence-group.ts
@@ -13,7 +13,8 @@ export class SequenceGroup<C extends TaskContext = TaskContext> extends GroupTas
   protected async* _orchestrate(): AsyncGenerator<Task> {
     for (const task of this.tasks) {
       if (this._stopped) {
-        break;
+        this.status = 'failed';
+        return;
       }
 
       // Start task
@@ -25,9 +26,11 @@ export class SequenceGroup<C extends TaskContext = TaskContext> extends GroupTas
 
       if (result.status === 'failed') {
         this.status = 'failed';
-        break;
+        return;
       }
     }
+
+    this.status = 'done';
   }
 
   protected _stop(): void {

--- a/src/sequence-group.ts
+++ b/src/sequence-group.ts
@@ -5,11 +5,22 @@ import { Task, TaskContext } from './task';
 
 // Class
 export class SequenceGroup<C extends TaskContext = TaskContext> extends GroupTask<C> {
+  // Attributes
+  private _stopped = false;
+  private _currentTask?: Task;
+
   // Methods
   protected async* _orchestrate(): AsyncGenerator<Task> {
     for (const task of this.tasks) {
+      if (this._stopped) {
+        break;
+      }
+
+      // Start task
+      this._currentTask = task;
       yield task;
 
+      // Wait task end
       const result = await waitForEvent(task, 'completed');
 
       if (result.status === 'failed') {
@@ -17,5 +28,12 @@ export class SequenceGroup<C extends TaskContext = TaskContext> extends GroupTas
         break;
       }
     }
+  }
+
+  protected _stop(): void {
+    this._stopped = true;
+
+    // Stop current task
+    this._currentTask?.stop();
   }
 }

--- a/src/sequence-group.ts
+++ b/src/sequence-group.ts
@@ -1,0 +1,21 @@
+import { GroupTask } from './group-task';
+import { TaskContext } from './task';
+import { TaskManager } from './task-manager';
+import { waitForEvent } from '@jujulego/event-tree';
+
+// Class
+export class SequenceGroup<C extends TaskContext = TaskContext> extends GroupTask<C> {
+  // Methods
+  protected async _orchestrate(manager: TaskManager) {
+    for (const task of this.tasks) {
+      manager.add(task);
+
+      const result = await waitForEvent(task, 'completed');
+
+      if (result.status === 'failed') {
+        this.status = 'failed';
+        break;
+      }
+    }
+  }
+}

--- a/src/sequence-group.ts
+++ b/src/sequence-group.ts
@@ -1,14 +1,14 @@
-import { GroupTask } from './group-task';
-import { TaskContext } from './task';
-import { TaskManager } from './task-manager';
 import { waitForEvent } from '@jujulego/event-tree';
+
+import { GroupTask } from './group-task';
+import { Task, TaskContext } from './task';
 
 // Class
 export class SequenceGroup<C extends TaskContext = TaskContext> extends GroupTask<C> {
   // Methods
-  protected async _orchestrate(manager: TaskManager) {
+  protected async* _orchestrate(): AsyncGenerator<Task> {
     for (const task of this.tasks) {
-      manager.add(task);
+      yield task;
 
       const result = await waitForEvent(task, 'completed');
 

--- a/src/spawn-task.ts
+++ b/src/spawn-task.ts
@@ -19,10 +19,10 @@ export interface SpawnTaskStreamEvent<S extends SpawnTaskStream = SpawnTaskStrea
   data: Buffer;
 }
 
-export type SpawnTaskEventMap = TaskEventMap & {
+export interface SpawnTaskEventMap extends TaskEventMap {
   'stream.stdout': SpawnTaskStreamEvent<'stdout'>;
   'stream.stderr': SpawnTaskStreamEvent<'stderr'>;
-};
+}
 
 // Class
 export class SpawnTask<C extends TaskContext = TaskContext, M extends SpawnTaskEventMap = SpawnTaskEventMap> extends Task<C, M> {

--- a/src/spawn-task.ts
+++ b/src/spawn-task.ts
@@ -51,7 +51,7 @@ export class SpawnTask<C extends TaskContext = TaskContext, M extends SpawnTaskE
   constructor(
     readonly cmd: string,
     readonly args: readonly string[],
-    context: Readonly<C>,
+    context: C,
     opts: SpawnTaskOptions = {}
   ) {
     super(context, {

--- a/src/task-manager.ts
+++ b/src/task-manager.ts
@@ -75,7 +75,7 @@ export class TaskManager extends EventSource<TaskManagerEventMap> {
       if (t.status === 'ready') {
         t.subscribe('completed', () => this._startNext(t));
 
-        t.start();
+        t.start(this);
         this._running.add(t);
 
         this.emit('started', t);

--- a/src/task-set.ts
+++ b/src/task-set.ts
@@ -1,6 +1,6 @@
 import { EventSource } from '@jujulego/event-tree';
 
-import { AnyTask, Task } from './task';
+import { AnyTask, assertIsTask, Task } from './task';
 import { TaskManager } from './task-manager';
 
 // Types
@@ -52,6 +52,8 @@ export class TaskSet extends EventSource<TaskSetEventMap> {
   }
 
   add(task: AnyTask): void {
+    assertIsTask(task);
+
     if (this._status !== 'created') {
       throw Error(`Cannot add a task to a ${this._status} task set`);
     }
@@ -61,7 +63,7 @@ export class TaskSet extends EventSource<TaskSetEventMap> {
     }
 
     // Listen to task's status
-    (task as Task).subscribe('status', ({ status }) => {
+    task.subscribe('status', ({ status }) => {
       if (status === 'running') {
         this.emit('started', task);
       } else if (status === 'done' || status === 'failed') {

--- a/src/task.ts
+++ b/src/task.ts
@@ -1,12 +1,13 @@
 import { EventSource } from '@jujulego/event-tree';
 import crypto from 'node:crypto';
 
+import { GroupTask } from './group-task';
 import { ILogger, logger } from './logger';
 import { TaskManager } from './task-manager';
 
 // Types
 export type TaskContext = Record<string, unknown> & {
-  groupTaskId?: string;
+  groupTask?: GroupTask;
 };
 
 export interface TaskOptions {
@@ -30,6 +31,11 @@ export type TaskEventMap = Record<`status.${TaskStatus}`, TaskStatusEvent> & {
 };
 
 export type AnyTask = Task<any, any>;
+
+// Utils
+export function assertIsTask(task: AnyTask): asserts task is Task {
+  return;
+}
 
 // Class
 export abstract class Task<C extends TaskContext = TaskContext, M extends TaskEventMap = TaskEventMap> extends EventSource<M> {
@@ -79,6 +85,8 @@ export abstract class Task<C extends TaskContext = TaskContext, M extends TaskEv
    * @param task the dependency to add
    */
   dependsOn(task: AnyTask): void {
+    assertIsTask(task);
+
     if (['blocked', 'ready'].includes(this._status)) {
       this._dependencies.push(task);
       this._recomputeStatus();

--- a/src/task.ts
+++ b/src/task.ts
@@ -2,9 +2,13 @@ import { EventSource } from '@jujulego/event-tree';
 import crypto from 'node:crypto';
 
 import { ILogger, logger } from './logger';
+import { TaskManager } from './task-manager';
 
 // Types
-export type TaskContext = Record<string, unknown>;
+export type TaskContext = Record<string, unknown> & {
+  groupTaskId?: string;
+};
+
 export interface TaskOptions {
   id?: string;
   logger?: ILogger;
@@ -50,7 +54,7 @@ export abstract class Task<C extends TaskContext = TaskContext, M extends TaskEv
   }
 
   // Methods
-  protected abstract _start(): void;
+  protected abstract _start(manager?: TaskManager): void;
   protected abstract _stop(): void;
 
   private _recomputeStatus(): void {
@@ -118,7 +122,7 @@ export abstract class Task<C extends TaskContext = TaskContext, M extends TaskEv
    * The task will be started only if it's status is "ready".
    * In other cases, it will throw an error.
    */
-  start(): void {
+  start(manager?: TaskManager): void {
     if (this._status !== 'ready') {
       throw Error(`Cannot start a ${this._status} task`);
     }
@@ -126,7 +130,7 @@ export abstract class Task<C extends TaskContext = TaskContext, M extends TaskEv
     this._logger.verbose(`Running ${this.name}`);
     this._startTime = Date.now();
     this.status = 'running';
-    this._start();
+    this._start(manager);
   }
 
   /**

--- a/src/task.ts
+++ b/src/task.ts
@@ -13,6 +13,7 @@ export type TaskContext = Record<string, unknown> & {
 export interface TaskOptions {
   id?: string;
   logger?: ILogger;
+  weight?: number;
 }
 
 export type TaskStatus = 'blocked' | 'ready' | 'running' | 'done' | 'failed';
@@ -47,6 +48,7 @@ export abstract class Task<C extends TaskContext = TaskContext, M extends TaskEv
 
   readonly context: C;
   readonly id: string;
+  readonly weight: number;
   protected readonly _logger: ILogger;
 
   // Constructor
@@ -56,6 +58,7 @@ export abstract class Task<C extends TaskContext = TaskContext, M extends TaskEv
     // Parse options
     this.context = context;
     this.id = opts.id ?? crypto.randomUUID();
+    this.weight = opts.weight ?? 1;
     this._logger = opts.logger ?? logger;
   }
 

--- a/tests/group-task.test.ts
+++ b/tests/group-task.test.ts
@@ -1,0 +1,70 @@
+import { Task } from '../src';
+import { TestGroupTask, TestTask } from './utils';
+
+// Setup
+let group: TestGroupTask;
+
+const taskAddedEventSpy = jest.fn<void, [Task]>();
+const taskStartedEventSpy = jest.fn<void, [Task]>();
+const taskCompletedEventSpy = jest.fn<void, [Task]>();
+
+beforeEach(() => {
+  group = new TestGroupTask('test');
+
+  jest.resetAllMocks();
+  jest.restoreAllMocks();
+
+  group.subscribe('task.added', taskAddedEventSpy);
+  group.subscribe('task.started', taskStartedEventSpy);
+  group.subscribe('task.completed', taskCompletedEventSpy);
+});
+
+// Tests
+describe('GroupTask.add', () => {
+  it('should add task to the group', () => {
+    const task = new TestTask('test-1');
+    group.add(task);
+    
+    expect(group.tasks).toContain(task);
+    expect(task.context.groupTask).toBe(group);
+
+    expect(taskAddedEventSpy).toHaveBeenCalledWith(task, {
+      key: 'task.added',
+      origin: group,
+    });
+  });
+
+  it('should emit task.started when a task is started', () => {
+    const task = new TestTask('test-1');
+    group.add(task);
+
+    task.status = 'running';
+
+    expect(taskStartedEventSpy).toHaveBeenCalledWith(task, {
+      key: 'task.started',
+      origin: group,
+    });
+  });
+
+  it('should emit task.completed when a task is completed', () => {
+    const task = new TestTask('test-1');
+    group.add(task);
+
+    task.emit('completed', { status: 'done', duration: 1000 });
+
+    expect(taskCompletedEventSpy).toHaveBeenCalledWith(task, {
+      key: 'task.completed',
+      origin: group,
+    });
+  });
+
+  it('should throw if task is already within a other group', () => {
+    const otherGroup = new TestGroupTask('other');
+
+    const task = new TestTask('test-1');
+    otherGroup.add(task);
+
+    expect(() => group.add(task))
+      .toThrow('Cannot add task test-1 to group test, it\'s already in group other');
+  });
+});

--- a/tests/group-task.test.ts
+++ b/tests/group-task.test.ts
@@ -119,3 +119,27 @@ describe('GroupTask.start', () => {
     );
   });
 });
+
+describe('GroupTask.stats', () => {
+  let task: TestTask;
+  
+  beforeEach(() => {
+    task = new TestTask('test-1');
+    group.add(task);
+  });
+
+  for (const status of ['blocked', 'ready', 'running', 'done', 'failed'] as const) {
+    it(`should return 1 for ${status} and 0 for other statuses`, () => {
+      task.status = status;
+
+      expect(group.stats).toEqual({
+        blocked: 0,
+        ready: 0,
+        running: 0,
+        done: 0,
+        failed: 0,
+        [status]: 1,
+      });
+    });
+  }
+});

--- a/tests/parallel-group.test.ts
+++ b/tests/parallel-group.test.ts
@@ -28,6 +28,7 @@ describe('ParallelGroup.start', () => {
     jest.spyOn(manager, 'add');
     await flushPromises();
 
+    expect(manager.add).toHaveBeenCalledTimes(3);
     expect(manager.add).toHaveBeenCalledWith(tasks[0]);
     expect(manager.add).toHaveBeenCalledWith(tasks[1]);
     expect(manager.add).toHaveBeenCalledWith(tasks[2]);

--- a/tests/parallel-group.test.ts
+++ b/tests/parallel-group.test.ts
@@ -1,0 +1,82 @@
+import { ParallelGroup, TaskManager } from '../src';
+import { flushPromises, spyLogger, TestTask } from './utils';
+
+// Setup
+let manager: TaskManager;
+let group: ParallelGroup;
+let tasks: TestTask[];
+
+beforeEach(() => {
+  manager = new TaskManager({ jobs: 8, logger: spyLogger });
+  group = new ParallelGroup('test', {}, { logger: spyLogger });
+  tasks = [
+    new TestTask('task-0'),
+    new TestTask('task-1'),
+    new TestTask('task-2'),
+  ];
+});
+
+// Tests
+describe('ParallelGroup.start', () => {
+  it('should add all task at once', async () => {
+    group.add(tasks[0]);
+    group.add(tasks[1]);
+    group.add(tasks[2]);
+
+    manager.add(group);
+
+    jest.spyOn(manager, 'add');
+    await flushPromises();
+
+    expect(manager.add).toHaveBeenCalledWith(tasks[0]);
+    expect(manager.add).toHaveBeenCalledWith(tasks[1]);
+    expect(manager.add).toHaveBeenCalledWith(tasks[2]);
+  });
+
+  it('should be done if all task are done', async () => {
+    group.add(tasks[0]);
+    group.add(tasks[1]);
+    group.add(tasks[2]);
+
+    manager.add(group);
+    await flushPromises();
+
+    tasks[0].status = 'done';
+    tasks[1].status = 'done';
+    tasks[2].status = 'done';
+
+    expect(group.status).toBe('done');
+  });
+
+  it('should be failed if one task is failed', async () => {
+    group.add(tasks[0]);
+    group.add(tasks[1]);
+    group.add(tasks[2]);
+
+    manager.add(group);
+    await flushPromises();
+
+    tasks[0].status = 'done';
+    tasks[1].status = 'done';
+    tasks[2].status = 'failed';
+
+    expect(group.status).toBe('failed');
+  });
+});
+
+describe('ParallelGroup.stop', () => {
+  it('should stop all tasks', async () => {
+    group.add(tasks[0]);
+    group.add(tasks[1]);
+    group.add(tasks[2]);
+
+    manager.add(group);
+    await flushPromises();
+
+    group.stop();
+
+    expect(tasks[0]._stop).toHaveBeenCalled();
+    expect(tasks[1]._stop).toHaveBeenCalled();
+    expect(tasks[2]._stop).toHaveBeenCalled();
+  });
+});

--- a/tests/sequence-group.test.ts
+++ b/tests/sequence-group.test.ts
@@ -1,0 +1,119 @@
+import { SequenceGroup, TaskManager } from '../src';
+import { flushPromises, spyLogger, TestTask } from './utils';
+
+// Setup
+let manager: TaskManager;
+let group: SequenceGroup;
+let tasks: TestTask[];
+
+beforeEach(() => {
+  manager = new TaskManager({ jobs: 8, logger: spyLogger });
+  group = new SequenceGroup('test', {}, { logger: spyLogger });
+  tasks = [
+    new TestTask('task-0'),
+    new TestTask('task-1'),
+    new TestTask('task-2'),
+  ];
+});
+
+// Tests
+describe('SequenceGroup.start', () => {
+  it('should add all task in sequence', async () => {
+    group.add(tasks[0]);
+    group.add(tasks[1]);
+    group.add(tasks[2]);
+
+    manager.add(group);
+
+    jest.spyOn(manager, 'add');
+    await flushPromises();
+
+    // should have added first
+    expect(manager.add).toHaveBeenCalledTimes(1);
+    expect(manager.add).toHaveBeenCalledWith(tasks[0]);
+
+    // complete first
+    tasks[0].status = 'done';
+    await flushPromises();
+
+    // should have added second
+    expect(manager.add).toHaveBeenCalledTimes(2);
+    expect(manager.add).toHaveBeenCalledWith(tasks[1]);
+  });
+
+  it('should be done if all task are done', async () => {
+    group.add(tasks[0]);
+    group.add(tasks[1]);
+    group.add(tasks[2]);
+
+    manager.add(group);
+    await flushPromises();
+
+    tasks[0].status = 'done';
+    await flushPromises();
+
+    tasks[1].status = 'done';
+    await flushPromises();
+
+    tasks[2].status = 'done';
+    await flushPromises();
+
+    expect(group.status).toBe('done');
+  });
+
+  it('should be failed if one task is failed and do not start next tasks', async () => {
+    group.add(tasks[0]);
+    group.add(tasks[1]);
+    group.add(tasks[2]);
+
+    manager.add(group);
+
+    jest.spyOn(manager, 'add');
+    await flushPromises();
+
+    tasks[0].status = 'failed';
+    await flushPromises();
+
+    expect(group.status).toBe('failed');
+    expect(manager.add).not.toHaveBeenCalledWith(tasks[1]);
+    expect(manager.add).not.toHaveBeenCalledWith(tasks[2]);
+  });
+});
+
+describe('SequenceGroup.stop', () => {
+  it('should stop running tasks and end group (task done)', async () => {
+    group.add(tasks[0]);
+    group.add(tasks[1]);
+    group.add(tasks[2]);
+
+    manager.add(group);
+    await flushPromises();
+
+    group.stop();
+    await flushPromises();
+
+    expect(tasks[0]._stop).toHaveBeenCalled();
+    tasks[0].status = 'done';
+    await flushPromises();
+
+    expect(group.status).toBe('failed');
+  });
+
+  it('should stop running tasks and end group (task failed)', async () => {
+    group.add(tasks[0]);
+    group.add(tasks[1]);
+    group.add(tasks[2]);
+
+    manager.add(group);
+    await flushPromises();
+
+    group.stop();
+    await flushPromises();
+
+    expect(tasks[0]._stop).toHaveBeenCalled();
+    tasks[0].status = 'failed';
+    await flushPromises();
+
+    expect(group.status).toBe('failed');
+  });
+});

--- a/tests/task-manager.test.ts
+++ b/tests/task-manager.test.ts
@@ -47,13 +47,25 @@ describe('TaskManager.add', () => {
     );
   });
 
-  it('should only start #jobs tasks a the same time (here 1)', () => {
+  it('should only start 1 task a the same time (sum of task weight < jobs options)', () => {
     manager.add(tasks[0]);
     manager.add(tasks[1]);
     manager.add(tasks[2]);
 
     expect(tasks[0].status).toBe('running');
     expect(tasks[1].status).toBe('ready');
+    expect(tasks[2].status).toBe('ready');
+  });
+
+  it('should only start 2 task a the same time (sum of task weight < jobs options)', () => {
+    const lightWeight = new TestTask('light weight', { weight: 0 });
+
+    manager.add(lightWeight);
+    manager.add(tasks[1]);
+    manager.add(tasks[2]);
+
+    expect(lightWeight.status).toBe('running');
+    expect(tasks[1].status).toBe('running');
     expect(tasks[2].status).toBe('ready');
   });
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,6 +1,6 @@
-import { ILogger, Task, TaskOptions, TaskStatus } from '../src';
+import { GroupTask, ILogger, Task, TaskOptions, TaskStatus } from '../src';
 
-// Class
+// Classes
 export class TestTask extends Task {
   // Constructor
   constructor(readonly name: string, opts: TaskOptions = {}) {
@@ -19,6 +19,16 @@ export class TestTask extends Task {
   set status(status: TaskStatus) {
     super.status = status;
   }
+}
+
+export class TestGroupTask extends GroupTask {
+  // Constructor
+  constructor(name: string, opts: TaskOptions = {}) {
+    super(name, {}, { logger: spyLogger, ...opts });
+  }
+
+  // Methods
+  _orchestrate = jest.fn();
 }
 
 // Logger

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -29,6 +29,7 @@ export class TestGroupTask extends GroupTask {
 
   // Methods
   _orchestrate = jest.fn();
+  _stop = jest.fn();
 }
 
 // Logger
@@ -36,4 +37,5 @@ export const spyLogger: ILogger = {
   debug: jest.fn(),
   verbose: jest.fn(),
   warn: jest.fn(),
+  error: jest.fn(),
 };

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -39,3 +39,8 @@ export const spyLogger: ILogger = {
   warn: jest.fn(),
   error: jest.fn(),
 };
+
+// Utils
+export function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}


### PR DESCRIPTION
`GroupTask` is a task orchestrating multiple "children" tasks. `GroupTask` itself is an abstract class and future groups will have to implement `_orchestrate` and `_stop` methods. `_orchestrate` manages group lifecycle: it should yield tasks to run, and update group's status.

#### Other features:
- Adds a "weight" to tasks allowing to define no-weight tasks, a task witch do not "decrement" job count of a manager.
- Adds `groupTask` to task base context, storing group containing task

#### Implemented groups:
- `ParallelGroup`: runs all children tasks at the same time. will be `done` only if __all__ children tasks are `done`
- `SequenceGroup`: runs children task one by one. the next task will be called only if the previous is `done`. will be done only if __all__ children tasks are `done`
